### PR TITLE
Ke/feature/is loading message

### DIFF
--- a/cypress/e2e/spec_Dashboard.cy.ts
+++ b/cypress/e2e/spec_Dashboard.cy.ts
@@ -102,7 +102,7 @@ describe('Dashboard Page Tests', () => {
         })
         cy.get('.link-name').first().should('contain', 'tur.link/dc79d5e0')
         cy.get('.click-count').first().should('contain', 0)
-        cy.get(':nth-child(2) > .link-name > a').click()
+        cy.get(':nth-child(2) > .link-name > .tooltip > a').click()
         cy.get(':nth-child(2) > .click-count').should('contain', 1)
         cy.get('@windowOpen').should('be.calledWith', 'https://2019.wattenberger.com/blog/css-cascade')
     })

--- a/src/Components/Dashboard/Dashboard.tsx
+++ b/src/Components/Dashboard/Dashboard.tsx
@@ -34,11 +34,11 @@ const Dashboard: React.FC = () => {
                     setLinks(fetchedLinks);
                 }
             })
+            .then(() => setIsLoading(false))
             .catch((err) => {
                 console.error("Error fetching links:", err);
                 setError("We encountered an unexpected error and were unable to load the top 5 links. Please try again later.");
-            });
-            setIsLoading(false)
+            });           
     }, [selectedTags]);
 
     useEffect(() => {
@@ -75,8 +75,8 @@ const Dashboard: React.FC = () => {
                 <h1>Dashboard</h1>
             </section>
             <section className="popular-links">
-                <h2>Popular Links</h2>
                 {isLoading && <p className="loading">The Top 5 Links are Loading.</p>}
+                <h2>Popular Links</h2>
                 {error && <p className="error-message">{error}</p>}
                 {!error && (
                     <div className="links-table">

--- a/src/Components/Dashboard/Dashboard.tsx
+++ b/src/Components/Dashboard/Dashboard.tsx
@@ -19,6 +19,7 @@ const Dashboard: React.FC = () => {
     const [selectedTags, setSelectedTags] = useState<string[]>([]);
     const [error, setError] = useState<string>("");
     const [selectedTagValue, setSelectedTagValue] = useState<string>("");
+    const [isLoading, setIsLoading] = useState<boolean>(true)
 
     useEffect(() => {
         fetchTopLinks(selectedTags.length > 0 ? selectedTags : undefined)
@@ -37,6 +38,7 @@ const Dashboard: React.FC = () => {
                 console.error("Error fetching links:", err);
                 setError("We encountered an unexpected error and were unable to load the top 5 links. Please try again later.");
             });
+            setIsLoading(false)
     }, [selectedTags]);
 
     useEffect(() => {
@@ -74,6 +76,7 @@ const Dashboard: React.FC = () => {
             </section>
             <section className="popular-links">
                 <h2>Popular Links</h2>
+                {isLoading && <p className="loading">The Top 5 Links are Loading.</p>}
                 {error && <p className="error-message">{error}</p>}
                 {!error && (
                     <div className="links-table">

--- a/src/Components/MyLinks/MyLinks.css
+++ b/src/Components/MyLinks/MyLinks.css
@@ -9,6 +9,11 @@
     background-color: white;
 }
 
+.my-links-loading {
+    font-size: 1.2em;
+    color: #3C4040;
+}
+
 .my-links-container h2 {
     font-size: 1.5em;
     color: #3C4040;
@@ -35,14 +40,20 @@
 }
 
 .link-item button {
-    background-color: #82E1E6;
-    border: none;
-    padding: 10px 20px;
-    color: #3C4040;
-    cursor: pointer;
-    font-size: 1em;
     border-radius: 5px;
     transition: background-color 0.3s;
+    padding: 10px 16px;
+    border: none;
+    background-color: #00bcd4;
+    border-radius: 4px;
+    margin-top: 20px;
+    color: white;
+    font-size: 1em;
+    cursor: pointer;
+    text-align: center;
+    align-self: center; 
+    width: 75%;
+    height: 3em;
 }
 
 .link-item button:hover {
@@ -86,8 +97,7 @@
     padding: 10px;
     border-radius: 5px;
     margin: 10px 0;
-    font-size: 0.9em;
-   
+    font-size: 0.9em;   
   }
 
 .delete-button {

--- a/src/Components/MyLinks/MyLinks.tsx
+++ b/src/Components/MyLinks/MyLinks.tsx
@@ -106,14 +106,12 @@ const MyLinks: React.FC = () => {
       <h2>My Links</h2>
       {errorMessage && <p className="error-message">{errorMessage}</p>}
       {links.length === 0 ? (
-        <p>No links available.</p>
+        <p className="my-links-loading">Thanks for your patience! We're loading your links page now.</p>
       ) : (
         links.map((link) => (
           <div key={link.id} className="link-item">
             <p>Original URL: {link.original}</p>
-            <p>Short URL: <a onClick={(event: React.MouseEvent<HTMLAnchorElement>) => handleClick(link.short, event)} href={link.short}>{link.short}</a>
-              {/* Short URL: <a href={link.short} target="_blank" rel="noopener noreferrer">{link.short}</a> */}
-            </p>
+            <p>Short URL: <a onClick={(event: React.MouseEvent<HTMLAnchorElement>) => handleClick(link.short, event)} href={link.short}>{link.short}</a></p>
             <div className="tags">
               {link.tags && link.tags.length > 0 ? (
                 link.tags.map((tag) => (
@@ -125,7 +123,7 @@ const MyLinks: React.FC = () => {
                 <span className="no-tags">No tags</span>
               )}
             </div>
-            <button onClick={() => openTagsPopup(link)}>Manage Tags</button>
+            <button className="manage-tags-button" onClick={() => openTagsPopup(link)}>Manage Tags</button>
           </div>
         ))
       )}


### PR DESCRIPTION
## Description of Changes
This PR implements functionality so the user is shown specific messages when the dashboard and my links pages are loading. Currently, the top 5 links on the dashboard are loaded so quickly that the message is shown for a split second before the page populated with the top 5 links. The message displayed on the my links pages is visible for a bit longer.

This PR also re-styles the manage tag buttons so the styling is more consistent with the other buttons in the application.

The last PR changed a className of a link on the dashboard page, which caused a failing Cypress test in the Dashboard test suite. This PR updates the className in the Dashboard test suite so the Cypress test is now passing. 

## What are the relevant tickets (if any) 

This PR is related to issue #10, and #52 will be closed upon successful merge of this PR request.

## Screenshots (if applicable)
N/A

## Testing
I navigated between Dashboard and My Links to confirm the error messages are displayed prior to the links being loaded.

## Checklist
- [x] The code follows the project's coding standards.
- [ ] Unit tests have been added or updated to cover the changes.
- [ ] Documentation has been updated to reflect the changes (if applicable).
- [x] The code compiles without errors.
- [x] The changes have been tested locally and pass all relevant tests.
- [x] All new and existing tests pass.
- [ ] The pull request has been reviewed by at least one other contributor.

## Reviewer Instructions
No specific instructions or information that would help the reviewer understand the context or nuances of the changes.

## Deployment Notes
No notes or instructions related to the deployment of this pull request.

## Additional Information
No additional information is relevant to the review or understanding of the changes. 
